### PR TITLE
Fix compilation of benchmarks

### DIFF
--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -7,7 +7,6 @@ import Criterion.Main
     ,   nf
     ,   whnf
     )
-import Criterion.Types ( Pure )
 
 -- | An example function to benchmark...
 --


### PR DESCRIPTION
#10 reports that the benchmarks are failing to compile due to a `Pure` import from `Criterion.Types`, as `Pure` no longer exists in `criterion-1`. However, this is itself a redundant import, so it can easily be removed.

Fixes #10.