### PR TITLE
bump cassava

### DIFF
--- a/cassava-conduit.cabal
+++ b/cassava-conduit.cabal
@@ -34,7 +34,7 @@ library
                     ,   array
                     ,   bifunctors              >= 4.2           && < 6
                     ,   bytestring              == 0.10.*
-                    ,   cassava                 == 0.4.*
+                    ,   cassava                 == 0.5.*
                     ,   conduit                 == 1.2.*
                     ,   conduit-extra           == 1.1.*
                     ,   mtl                     == 2.2.*
@@ -60,7 +60,7 @@ test-suite              quickcheck
 
     build-depends:      base                >= 4 && < 5
                       , bytestring          == 0.10.*
-                      , cassava             == 0.4.*
+                      , cassava             == 0.5.*
                       , conduit             == 1.2.*
                       , conduit-extra       == 1.1.*
                       , QuickCheck          == 2.9.*


### PR DESCRIPTION
# Notes

There were some semantic changes going from `cassava` `0.4.* -> 0.5.*`, see [here](https://github.com/hvr/cassava/blob/master/CHANGES.md#version-0500)

But I don't think they muddle with any of the explicit `cassava-conduit` semantics:

- `QuoteMinimal` semantics are not defined by `cassava-conduit`, so it will change behaviour, but `cassava-conduit` wont compensate for it.
- it doesn't use `foldl'`
- `cassava-conduit` doesn't use `encodeByNamedWith` so the `encIncludeHeader` flag shouldn't have any effect.

# Change Details

- bump `cassava`