### PR TITLE
bump conduit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ internal/
 exampledata/
 
 TAGS
+
+# stack working dir
+.stack-work/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,6 @@ cache:
 
 matrix:
   include:
-  - env: GHCVER=7.10.2 CABALVER=1.24
-    addons:
-      apt:
-        sources:
-          - hvr-ghc
-        packages:
-          - ghc-7.10.2
-          - cabal-install-1.24
   - env: GHCVER=8.0.2 CABALVER=1.24
     addons:
       apt:
@@ -26,6 +18,14 @@ matrix:
           - hvr-ghc
         packages:
           - ghc-8.0.2
+          - cabal-install-1.24
+  - env: GHCVER=8.2.2 CABALVER=1.24
+    addons:
+      apt:
+        sources:
+          - hvr-ghc
+        packages:
+          - ghc-8.2.2
           - cabal-install-1.24
   #allow-failures:
   #  - env: GHCVER=head

--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ $ cabal build
 ``` Shell
 ./mafia test
 ```
+

--- a/cassava-conduit.cabal
+++ b/cassava-conduit.cabal
@@ -36,7 +36,6 @@ library
                     ,   bytestring              == 0.10.*
                     ,   cassava                 == 0.5.*
                     ,   conduit                 == 1.3.*
-                    ,   conduit-extra           == 1.3.*
                     ,   mtl                     == 2.2.*
                     ,   text                    == 1.2.*
 
@@ -62,7 +61,6 @@ test-suite              quickcheck
                       , bytestring          == 0.10.*
                       , cassava             == 0.5.*
                       , conduit             == 1.3.*
-                      , conduit-extra       == 1.3.*
                       , QuickCheck          == 2.10.*
                       , text                == 1.2.*
                       , cassava-conduit

--- a/quickcheck/Test/Data/Csv/Conduit.hs
+++ b/quickcheck/Test/Data/Csv/Conduit.hs
@@ -14,7 +14,7 @@ import Data.Csv.Conduit
 
 import qualified Data.ByteString as BS
 import Data.Csv (HasHeader(..), defaultDecodeOptions)
-import Data.Conduit (($$), (=$=))
+import Data.Conduit ((.|), runConduit)
 import Data.Conduit.List (sourceList, consume)
 import Data.Functor ((<$>))
 import Data.List (length)
@@ -44,10 +44,10 @@ parsesAllRows g =
   forAll (diceIt g) $ \(expectedRows, chunks) ->
     let
       result :: Either CsvParseError [[Int]]
-      result =
-            sourceList chunks
-        $$  fromCsv defaultDecodeOptions NoHeader
-        =$= consume
+      result = runConduit
+         $ sourceList chunks
+        .| fromCsv defaultDecodeOptions NoHeader
+        .| consume
     in (length <$> result) === pure expectedRows
 
 prop_parsesAllRowsWithNewline :: Property

--- a/src/Data/Csv/Conduit.hs
+++ b/src/Data/Csv/Conduit.hs
@@ -31,7 +31,7 @@ import Control.Monad.Error.Class (MonadError(..))
 import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
-import Data.Conduit (Conduit, await, yield)
+import Data.Conduit (ConduitT, await, yield)
 import Data.Conduit.List (map, mapM)
 import Data.Csv (FromNamedRecord, FromRecord, ToRecord, DecodeOptions, EncodeOptions, HasHeader, encodeWith)
 import Data.Csv.Incremental (HeaderParser(..), Parser(..), decodeByNameWith, decodeWith)
@@ -62,14 +62,14 @@ data CsvStreamRecordParseError =
 -- Streams parsed records, Errors are not received in the stream but instead after the pipeline is executed,
 -- If you want to handle errors as they come and resume, see `fromCsvStreamError`
 --
-fromCsv :: (FromRecord a, MonadError CsvParseError m) => DecodeOptions -> HasHeader -> Conduit BS.ByteString m a
+fromCsv :: (FromRecord a, MonadError CsvParseError m) => DecodeOptions -> HasHeader -> ConduitT BS.ByteString a m ()
 fromCsv = fromCsvLiftError id
 
 -- |
 -- Sometimes your pipeline will involve an error type other than `CsvParseError`, in which case if you provide
 -- a function to project it into your custom error type, you can use this instead of `fromCsv`
 --
-fromCsvLiftError :: (FromRecord a, MonadError e m) => (CsvParseError -> e) -> DecodeOptions -> HasHeader -> Conduit BS.ByteString m a
+fromCsvLiftError :: (FromRecord a, MonadError e m) => (CsvParseError -> e) -> DecodeOptions -> HasHeader -> ConduitT BS.ByteString a m ()
 fromCsvLiftError f opts h = {-# SCC fromCsvLiftError_p #-} terminatingStreamParser f $ decodeWith opts h
 
 
@@ -79,42 +79,42 @@ fromCsvLiftError f opts h = {-# SCC fromCsvLiftError_p #-} terminatingStreamPars
 -- Errors are not seen in the pipeline but rather at the end after executing the pipeline, if you want to handle the errors
 -- as they occur, try `fromNamedCsvStreamError` instead.
 --
-fromNamedCsv :: (FromNamedRecord a, MonadError CsvParseError m) => DecodeOptions -> Conduit BS.ByteString m a
+fromNamedCsv :: (FromNamedRecord a, MonadError CsvParseError m) => DecodeOptions -> ConduitT BS.ByteString a m ()
 fromNamedCsv = fromNamedCsvLiftError id
 
 -- |
 -- Sometimes your pipeline will involve an error type other than `CsvParseError`, in which case if you provide
 -- a function to project it into your custom error type, you can use this instead of `fromCsv`
 --
-fromNamedCsvLiftError :: (FromNamedRecord a, MonadError e m) => (CsvParseError -> e) -> DecodeOptions -> Conduit BS.ByteString m a
+fromNamedCsvLiftError :: (FromNamedRecord a, MonadError e m) => (CsvParseError -> e) -> DecodeOptions -> ConduitT BS.ByteString a m ()
 fromNamedCsvLiftError f opts = {-# SCC fromNamedCsv_p #-} terminatingStreamHeaderParser f $ decodeByNameWith opts
 
 -- |
 -- Same as `fromCsv` but allows for errors to be handled in the pipeline instead
 --
-fromCsvStreamError :: (FromRecord a, MonadError e m) => DecodeOptions -> HasHeader -> (CsvStreamHaltParseError -> e) -> Conduit BS.ByteString m (Either CsvStreamRecordParseError a)
+fromCsvStreamError :: (FromRecord a, MonadError e m) => DecodeOptions -> HasHeader -> (CsvStreamHaltParseError -> e) -> ConduitT BS.ByteString (Either CsvStreamRecordParseError a) m ()
 fromCsvStreamError opts h f = {-# SCC fromCsvStreamError_p #-} streamParser f $ decodeWith opts h
 
 -- |
 -- Like `fromNamedCsvStream` but allows for errors to be handled in the pipeline itself.
 --
-fromNamedCsvStreamError :: (FromNamedRecord a, MonadError e m) => DecodeOptions -> (CsvStreamHaltParseError -> e) -> Conduit BS.ByteString m (Either CsvStreamRecordParseError a)
+fromNamedCsvStreamError :: (FromNamedRecord a, MonadError e m) => DecodeOptions -> (CsvStreamHaltParseError -> e) -> ConduitT BS.ByteString (Either CsvStreamRecordParseError a) m ()
 fromNamedCsvStreamError opts f = {-# SCC fromCsvStreamError_p #-} streamHeaderParser f $ decodeByNameWith opts
 
 -- |
 -- Streams from csv to text, does not create headers...
 --
-toCsv :: (Monad m, ToRecord a) => EncodeOptions -> Conduit a m BS.ByteString
+toCsv :: (Monad m, ToRecord a) => EncodeOptions -> ConduitT a BS.ByteString m ()
 toCsv opts = {-# SCC toCsv_p #-} map $ BSL.toStrict . encodeWith opts . pure
 
 -- helpers
 
-streamHeaderParser :: (MonadError e m) => (CsvStreamHaltParseError -> e) -> HeaderParser (Parser a) -> Conduit BS.ByteString m (Either CsvStreamRecordParseError a)
+streamHeaderParser :: (MonadError e m) => (CsvStreamHaltParseError -> e) -> HeaderParser (Parser a) -> ConduitT BS.ByteString (Either CsvStreamRecordParseError a) m ()
 streamHeaderParser f (FailH rest errMsg)  = {-# SCC streamHeaderParser_FailH_p #-} lift . throwError . f $ HaltingCsvParseError rest (T.pack errMsg)
 streamHeaderParser f (PartialH p)         = {-# SCC streamHeaderParser_PartialH_p #-} await >>= maybe (return ()) (streamHeaderParser f . p)
 streamHeaderParser f (DoneH _ p)          = {-# SCC streamHeaderParser_DoneH_p #-} streamParser f p
 
-streamParser :: (MonadError e m) => (CsvStreamHaltParseError -> e) -> Parser a -> Conduit BS.ByteString m (Either CsvStreamRecordParseError a)
+streamParser :: (MonadError e m) => (CsvStreamHaltParseError -> e) -> Parser a -> ConduitT BS.ByteString (Either CsvStreamRecordParseError a) m ()
 streamParser f (Fail rest errMsg)   = {-# SCC streamParser_Fail_p #-} lift . throwError . f $ HaltingCsvParseError rest (T.pack errMsg)
 streamParser f (Many rs p)          = {-# SCC streamParser_Many_p #-} do
   -- send the results down the stream..
@@ -128,7 +128,7 @@ terminatingStreamHeaderParser
   :: (Monad m, MonadError e m)
   => (CsvParseError -> e)
   -> HeaderParser (Parser a)
-  -> Conduit BS.ByteString m a
+  -> ConduitT BS.ByteString a m ()
 terminatingStreamHeaderParser f (FailH rest errMsg)   = {-# SCC terminatingStreamHeaderParser_FailH_p #-} lift . throwError . f . CsvParseError rest . T.pack $ errMsg
 terminatingStreamHeaderParser f (PartialH p)          = {-# SCC terminatingStreamHeaderParser_PartialH_p #-} await >>= maybe (return ()) (terminatingStreamHeaderParser f . p)
 terminatingStreamHeaderParser f (DoneH _ p)           = {-# SCC terminatingStreamHeaderParser_DoneH_p #-} terminatingStreamParser f p
@@ -137,19 +137,19 @@ terminatingStreamParser
   :: (Monad m, MonadError e m)
   => (CsvParseError -> e)
   -> Parser a
-  -> Conduit BS.ByteString m a
+  -> ConduitT BS.ByteString a m ()
 terminatingStreamParser f (Fail rest errMsg)    = {-# SCC terminatingStreamParser_Fail_p #-} lift . throwError . f . CsvParseError rest . T.pack $ errMsg
 terminatingStreamParser f (Many ers p)          = {-# SCC terminatingStreamParser_Many_p #-}
   let
-    errorHandler :: (Monad m, MonadError e m) => (CsvParseError -> e) -> String -> Conduit BS.ByteString m a
+    errorHandler :: (Monad m, MonadError e m) => (CsvParseError -> e) -> String -> ConduitT BS.ByteString a m ()
     errorHandler f' = mapM . const . throwError . f' . IncrementalError . T.pack
 
     safeResultHandler
       :: (Monad m)
       => (BS.ByteString -> Parser a)
-      -> (Parser a -> Conduit BS.ByteString m a)
+      -> (Parser a -> ConduitT BS.ByteString a m ())
       -> [a]
-      -> Conduit BS.ByteString m a
+      -> ConduitT BS.ByteString a m ()
     safeResultHandler p' f' rs = do
       mapM_ yield rs
       -- wait for more..


### PR DESCRIPTION
This is a minor blocker for me, so I went ahead with the required patches to get this working.

### summary of changes
- Addressed deprecation warnings
  - `Conduit` -> `ConduitT`
  - `=S=` -> `.|`
  - `$$` -> `runConduit`
- Removed `conduit-extra` without any apparent loss of functionality.
- Bumped travis build matrix with newer GHC ver. conduit-1.3 requires `ghc-8.0.2/base-4.9` minimum.