### PR TITLE
Add `fromCsvStreamErrorNoThrow` and `fromNamedCsvStreamErrorNoThrow`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 0.6.x
+# 0.6.1
+
+- Add `fromCsvStreamErrorNoThrow` and `fromNamedCsvStreamErrorNoThrow`, functions that also put halting errors on the conduit instead of throwing in `MonadError`.
+
+# 0.6.0
 
 - `streamParser` and functions using it would swallow certain runaway errors. This is fixed.
 

--- a/cassava-conduit.cabal
+++ b/cassava-conduit.cabal
@@ -1,5 +1,5 @@
 name:               cassava-conduit
-version:            0.6.0
+version:            0.6.1
 license:            BSD3
 license-file:       etc/LICENCE.md
 author:             Dom De Re


### PR DESCRIPTION
There was no good way to put all errors on the stream in a pure
fashion.

The matrix of named x throw x noThrow is getting a bit unwieldy, but
that’s for a future refactor to fix.