### PR TITLE
bytestring => 0.11* (built with ghc 9.2.5)

### DIFF
--- a/cassava-conduit.cabal
+++ b/cassava-conduit.cabal
@@ -33,7 +33,7 @@ library
                     ,   containers
                     ,   array
                     ,   bifunctors              >= 4.2           && < 6
-                    ,   bytestring              == 0.10.*
+                    ,   bytestring              == 0.11.*
                     ,   cassava                 == 0.5.*
                     ,   conduit                 == 1.3.*
                     ,   mtl                     == 2.2.*
@@ -58,7 +58,7 @@ test-suite              quickcheck
                         Test.Data.Csv.Conduit
 
     build-depends:      base                >= 4 && < 5
-                      , bytestring          == 0.10.*
+                      , bytestring          == 0.11.*
                       , cassava             == 0.5.*
                       , conduit             == 1.3.*
                       , QuickCheck          == 2.12.*


### PR DESCRIPTION
resolves #31 