### PR TITLE
Support text >= 2

### DIFF
--- a/cassava-conduit.cabal
+++ b/cassava-conduit.cabal
@@ -37,7 +37,7 @@ library
                     ,   cassava                 == 0.5.*
                     ,   conduit                 == 1.3.*
                     ,   mtl                     == 2.2.*
-                    ,   text                    == 1.2.*
+                    ,   text                    == 1.2.* || >=2.0 && <2.1
 
     ghc-options:        -Wall
 
@@ -62,7 +62,7 @@ test-suite              quickcheck
                       , cassava             == 0.5.*
                       , conduit             == 1.3.*
                       , QuickCheck          == 2.12.*
-                      , text                == 1.2.*
+                      , text                == 1.2.* || >=2.0 && <2.1
                       , cassava-conduit
 
 benchmark               benchmarks


### PR DESCRIPTION
https://github.com/domdere/cassava-conduit/issues/31 mentions text, but it didn't get bumped in https://github.com/domdere/cassava-conduit/pull/32.

This is necessary for the nightly stackage builds that support GHC 9.4.

I _believe_ only a bounds change is required (I've got the library building successfully with `text-2.0.1`).